### PR TITLE
calculate hash before loading cht file

### DIFF
--- a/cheats2.cpp
+++ b/cheats2.cpp
@@ -11,6 +11,10 @@
 #include "cheats.h"
 #include "bml.h"
 
+#ifdef RETROACHIEVEMENTS
+#include "RetroAchievements.h"
+#endif
+
 static inline char *trim (char *string)
 {
     int start;
@@ -334,6 +338,11 @@ void S9xEnableCheat (SCheat *c)
 void S9xEnableCheatGroup (uint32 num)
 {
     unsigned int i;
+
+#ifdef RETROACHIEVEMENTS
+    if (RA_HardcoreModeIsActive())
+        return;
+#endif
 
     for (i = 0; i < Cheat.g[num].c.size (); i++)
     {

--- a/memmap.cpp
+++ b/memmap.cpp
@@ -35,6 +35,10 @@
 #include "display.h"
 #include "sha256.h"
 
+#ifdef RETROACHIEVEMENTS
+#include "RetroAchievements.h"
+#endif
+
 #ifndef SET_UI_COLOR
 #define SET_UI_COLOR(r, g, b) ;
 #endif
@@ -1623,6 +1627,11 @@ bool8 CMemory::LoadROMInt (int32 ROMfillSize)
 	S9xReset();
 
 	S9xDeleteCheats();
+
+#ifdef RETROACHIEVEMENTS
+	RA_OnLoadNewRom();
+#endif
+
 	S9xLoadCheatFile(S9xGetFilename(".cht", CHEAT_DIR));
 
     return (TRUE);

--- a/win32/wsnes9x.cpp
+++ b/win32/wsnes9x.cpp
@@ -4073,9 +4073,6 @@ static bool LoadROMPlain(const TCHAR *filename)
 	SetCurrentDirectory(S9xGetDirectoryT(ROM_DIR));
     if (Memory.LoadROM (_tToChar(filename)))
     {
-#ifdef RETROACHIEVEMENTS
-		RA_OnLoadNewRom();
-#endif
 		S9xStartCheatSearch (&Cheat);
         ReInitSound();
 		ResetFrameTimer();


### PR DESCRIPTION
Fixes an issue where loading a cht file that modifies the ROM data would prevent the game from loading in non-hardcore mode.

cht was correctly not applied and did not affect loading the ROM when hardcore was enabled.